### PR TITLE
Fixes for Bing's webmaster guidelines

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <!-- CONTENT -->
 <div class="pure-u-1">
-    <h1 style="text-align: center">~ {{ humanize .Title }} ~</h1>
+    <h2 style="text-align: center">~ {{ humanize .Title }} ~</h2>
 </div>
 <div class="pure-g">
     {{ if (eq .RelPermalink "/tags/") }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <!-- CONTENT -->
 <div class="pure-u-1">
-    <h2 style="text-align: center">~ {{ humanize .Title }} ~</h2>
+    <h1 style="text-align: center">~ {{ humanize .Title }} ~</h1>
 </div>
 <div class="pure-g">
     {{ if (eq .RelPermalink "/tags/") }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,8 @@
 {{ define "main" }}
 {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) 10 }}
 <div id="content" class="pure-u-1 pure-u-md-3-4 pure-u-sm-1">
-    {{ range .Paginator.Pages }}
+  <h1><center>Recent Posts</center></h1>
+  {{ range .Paginator.Pages }}
 
     <div class="pad">
         {{- partial "render_single_article.html" . -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) 10 }}
+
 <div id="content" class="pure-u-1 pure-u-md-3-4 pure-u-sm-1">
-  <h1><center>Recent Posts</center></h1>
-  {{ range .Paginator.Pages }}
+    <h1 style="text-align: center; margin: 0;">
+        Recent Posts (page {{ $paginator.PageNumber }} / {{ $paginator.TotalPages }})
+    </h1>
+
+    {{ range .Paginator.Pages }}
 
     <div class="pad">
         {{- partial "render_single_article.html" . -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,7 @@
 
     {{ range .Paginator.Pages }}
 
+    {{ .Scratch.Set "isMainPage" "true" }}
     <div class="pad">
         {{- partial "render_single_article.html" . -}}
     </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,16 +2,16 @@
     <meta charset="utf-8">
     <meta name="theme-color" content="#000" />
     <title>
-        {{ if .IsHome }}
-            {{ if .Site.Title }} 
-                {{ .Site.Title }} 
-            {{ else }}
-                {{ .Site.Params.Title }} 
-            {{ end }} 
-            &middot; {{ .Site.Params.Tagline }}
-        {{ else }}
-            {{ .Title }} &middot; {{ .Site.Title }} {{ .Site.Params.Title }}
-        {{ end }}
+        {{- if .IsHome -}}
+            {{ if .Site.Title -}} 
+                {{ .Site.Title -}} 
+            {{ else -}}
+                {{ .Site.Params.Title -}} 
+            {{ end -}} 
+            &middot; {{ .Site.Params.Tagline -}}
+        {{ else -}}
+            {{ .Title }} &middot; {{ .Site.Title }} {{ .Site.Params.Title -}}
+        {{- end -}}
     </title>
 
     <!-- Stylesheets -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,15 +32,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="{{ hugo.Generator }}">
     
-    {{ if .Description }}
+    {{ if .Description -}}
     <meta name="description" content="{{ .Description }}">
-    {{ else }}
+    {{ else -}}
     <meta name="description" content="{{ .Site.Params.Tagline }}">
-    {{ end }}
+    {{ end -}}
 
-    {{ if .Params.tags }}
+    {{ if .Params.tags -}}
     <meta name="keywords" content="{{ delimit .Params.tags "," }}">
-    {{ end }}
+    {{ end -}}
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{- partial "custom_header.html" . -}}

--- a/layouts/partials/render_single_article.html
+++ b/layouts/partials/render_single_article.html
@@ -5,7 +5,11 @@
 </div>
 {{ end }}
 <article>
+    {{ if eq (.Scratch.Get "isMainPage") "true"  -}}
     <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+    {{ else -}}
+    <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
+    {{- end -}}
     <div class="tags">
         {{ range .Params.tags }}
         {{ $name := . }}

--- a/layouts/partials/render_single_article.html
+++ b/layouts/partials/render_single_article.html
@@ -5,7 +5,7 @@
 </div>
 {{ end }}
 <article>
-    <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
+    <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
     <div class="tags">
         {{ range .Params.tags }}
         {{ $name := . }}


### PR DESCRIPTION
Bing's web crawler whines about having too many `<h1>` tags on a page. and when some meta tags are too long. This PR makes sure there is only 1 `<h1>` tag per page and removes some of the empty lines to make the meta tags shorter. The visible change is that article titles are now `<h2>` (on the home page and the articles list) and the addition of a header to the index page (as the single `<h1>` tag)