### PR TITLE
Add OpenGraph and Twitter specific meta tags to header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="type" property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
-    <meta name="image" property="og:image" content="{{ $imageLink }}">
+    <meta name="image" property="og:image" content="http://friendgineers.rosenshein.org{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
     <meta name="twitter:card" content="summary">
     <meta property=”og:type” content=”blog”>
     <meta property="og:description" content="{{ $descText }}">
-    <meta property="og:image" content="http://friendgineers.rosenshein.org{{ $imageLink }}">
+    <meta property="og:image" content="{{ $imageLink | absURL }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="type" property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
-    <meta name="image" property="og:image" content="http://friendgineers.rosenshein.org{{ $imageLink }}">
+    <meta name="image" property="og:image:secure_url" content="https://friendgineers.rosenshein.org{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -52,6 +52,13 @@
     {{$imageLink = .Site.Params.authorImgPath -}}
     {{ end -}}
 
+    <!-- This block handles relative paths to the preview image -->
+    {{- if .File.Dir -}}
+    {{ if not (hasPrefix $imageLink "/") -}}
+    {{ $imageLink = path.Join .File.Dir $imageLink -}}
+    {{ end -}}
+    {{ end -}}
+
     {{ "<!-- OpenGraph/Twitter Specific Stuff-->" | safeHTML }}
     <meta name="twitter:card" content="summary">
     <meta property=”og:type” content=”blog”>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -38,10 +38,19 @@
     <meta name="description" property="og:description" content="{{ .Description }}">
     {{ else -}}
     <meta name="description" property="og:description" content="{{ .Site.Params.Tagline }}">
-    {{ end -}}
+    {{ end }}
+
+    {{ "<!-- Twitter Specific Stuff-->" | safeHTML }}
+    <meta name="twitter:card" content="summary">
+    {{ if .Site.Social.twitteruser -}}
+    <meta name="twitter:creator" content="{{ .Site.Social.twitteruser }}">
+    {{ end }}
+    {{- if not .IsHome -}}
+    <meta name="title" property="twitter:title" content="{{ .Title }}">
+    {{ end }}
 
     {{ if .Params.tags -}}
-    <meta name="keywords" content="{{ delimit .Params.tags "," }}">
+    <meta name=" keywords" content="{{ delimit .Params.tags "," }}">
     {{ end -}}
     <meta name="author" content="{{ .Site.Params.Author }}">
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,6 +57,7 @@
     <meta property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
     <meta property="og:image" content="{{.Site.BaseURL}}{{ $imageLink }}">
+    <meta property="twitter:image" content="{{.Site.BaseURL}}{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -53,7 +53,7 @@
     {{ end -}}
 
     {{ "<!-- OpenGraph/Twitter Specific Stuff-->" | safeHTML }}
-    <meta name="twitter:card" content="summary">
+    <meta name="twitter:card" content="summary_large_image">
     <meta property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
     <meta property="og:image" content="{{ $imageLink }}">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="type" property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
-    <meta name="image" property="og:image:secure_url" content="https://friendgineers.rosenshein.org{{ $imageLink }}">
+    <meta name="image" property="og:image" content="http://friendgineers.rosenshein.org{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,14 +3,14 @@
     <meta name="theme-color" content="#000" />
     <title>
         {{- if .IsHome -}}
-            {{ if .Site.Title -}} 
-                {{ .Site.Title -}} 
-            {{ else -}}
-                {{ .Site.Params.Title -}} 
-            {{ end -}} 
-            &middot; {{ .Site.Params.Tagline -}}
+        {{ if .Site.Title -}}
+        {{ .Site.Title -}}
         {{ else -}}
-            {{ .Title }} &middot; {{ .Site.Title }} {{ .Site.Params.Title -}}
+        {{ .Site.Params.Title -}}
+        {{ end -}}
+        &middot; {{ .Site.Params.Tagline -}}
+        {{ else -}}
+        {{ .Title }} &middot; {{ .Site.Title }} {{ .Site.Params.Title -}}
         {{- end -}}
     </title>
 
@@ -24,18 +24,20 @@
     <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
     <!--<![endif]-->
     <link rel="stylesheet" href="/css/style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Fira+Sans+Condensed:wght@300&family=Bitter:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Fira+Sans+Condensed:wght@300&family=Bitter:ital,wght@0,400;0,700;1,400&display=swap"
+        rel="stylesheet">
     <link rel="icon" href="/img/favicon.ico" type="image/x-icon">
 
     <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="/atom.xml" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="{{ hugo.Generator }}">
-    
+
     {{ if .Description -}}
-    <meta name="description" content="{{ .Description }}">
+    <meta name="description" property="og:description" content="{{ .Description }}">
     {{ else -}}
-    <meta name="description" content="{{ .Site.Params.Tagline }}">
+    <meta name="description" property="og:description" content="{{ .Site.Params.Tagline }}">
     {{ end -}}
 
     {{ if .Params.tags -}}
@@ -43,7 +45,14 @@
     {{ end -}}
     <meta name="author" content="{{ .Site.Params.Author }}">
 
-    {{- partial "custom_header.html" . -}}
+    {{ if .Params.Previewimage -}}
+    <meta name="image" property="og:image" content="{{ .Params.Previewimage }}">
+    {{ else -}}
+    <meta name="image" property="og:image" content="{{ .Site.Params.AuthorImgPath }}">
+    {{ end }}
+
+    {{ "<!-- Any custom header goes here-->" | safeHTML }}
+    {{ partial "custom_header.html" . }}
 
     {{ template "_internal/google_analytics.html" . }}
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -54,9 +54,9 @@
 
     {{ "<!-- OpenGraph/Twitter Specific Stuff-->" | safeHTML }}
     <meta name="twitter:card" content="summary_large_image">
-    <meta property=”og:type” content=”blog”>
+    <meta name="type" property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
-    <meta property="og:image" content="{{ $imageLink }}">
+    <meta name="image" property="og:image" content="{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -46,10 +46,10 @@
     {{ end -}}
 
     {{ $imageLink := "" -}}
-    {{ if .Description -}}
-    {{$imageLink = .Description -}}
+    {{ if .Params.previewimage -}}
+    {{$imageLink = .Params.previewimage -}}
     {{ else -}}
-    {{$imageLink = .Site.Params.Tagline -}}
+    {{$imageLink = .Site.Params.authorImgPath -}}
     {{ end -}}
 
     {{ "<!-- OpenGraph/Twitter Specific Stuff-->" | safeHTML }}
@@ -59,7 +59,7 @@
     <meta property="og:image" content="{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
-    {{- if not .IsHome -}}
+    {{ if not .IsHome -}}
     <meta property="og:title" content="{{ .Title }}">
     {{ end -}}
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,8 +56,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
-    <meta property="og:image" content="{{.Site.BaseURL}}{{ $imageLink }}">
-    <meta property="twitter:image" content="{{.Site.BaseURL}}{{ $imageLink }}">
+    <meta property="og:image" content="{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -54,9 +54,9 @@
 
     {{ "<!-- OpenGraph/Twitter Specific Stuff-->" | safeHTML }}
     <meta name="twitter:card" content="summary">
-    <meta name="type" property=”og:type” content=”blog”>
-    <meta name="description" property="og:description" content="{{ $descText }}">
-    <meta name="image" property="og:image" content="http://friendgineers.rosenshein.org{{ $imageLink }}">
+    <meta property=”og:type” content=”blog”>
+    <meta property="og:description" content="{{ $descText }}">
+    <meta property="og:image" content="http://friendgineers.rosenshein.org{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -53,7 +53,7 @@
     {{ end -}}
 
     {{ "<!-- OpenGraph/Twitter Specific Stuff-->" | safeHTML }}
-    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:card" content="summary">
     <meta name="type" property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
     <meta name="image" property="og:image" content="http://friendgineers.rosenshein.org{{ $imageLink }}">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta property=”og:type” content=”blog”>
     <meta name="description" property="og:description" content="{{ $descText }}">
-    <meta property="og:image" content="{{ $imageLink }}">
+    <meta property="og:image" content="{{.Site.BaseURL}}{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
     {{ if not .IsHome -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,32 +32,39 @@
     <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="/atom.xml" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="generator" content="{{ hugo.Generator }}">
+    {{ hugo.Generator }}"
 
-    {{ if .Description -}}
-    <meta name="description" property="og:description" content="{{ .Description }}">
-    {{ else -}}
-    <meta name="description" property="og:description" content="{{ .Site.Params.Tagline }}">
-    {{ end }}
-
-    {{ "<!-- Twitter Specific Stuff-->" | safeHTML }}
-    <meta name="twitter:card" content="summary">
-    {{ if .Site.Social.twitteruser -}}
-    <meta name="twitter:creator" content="{{ .Site.Social.twitteruser }}">
-    {{ end }}
-    {{- if not .IsHome -}}
-    <meta name="title" property="twitter:title" content="{{ .Title }}">
-    {{ end }}
-
-    {{ if .Params.tags -}}
+    {{- if .Params.tags }}
     <meta name=" keywords" content="{{ delimit .Params.tags "," }}">
+    {{- end }}
+
+    {{ $descText := "" -}}
+    {{ if .Description -}}
+    {{$descText = .Description -}}
+    {{ else -}}
+    {{$descText = .Site.Params.Tagline -}}
     {{ end -}}
+
+    {{ $imageLink := "" -}}
+    {{ if .Description -}}
+    {{$imageLink = .Description -}}
+    {{ else -}}
+    {{$imageLink = .Site.Params.Tagline -}}
+    {{ end -}}
+
+    {{ "<!-- OpenGraph/Twitter Specific Stuff-->" | safeHTML }}
+    <meta name="twitter:card" content="summary">
+    <meta property=”og:type” content=”blog”>
+    <meta name="description" property="og:description" content="{{ $descText }}">
+    <meta property="og:image" content="{{ $imageLink }}">
     <meta name="author" content="{{ .Site.Params.Author }}">
 
-    {{ if .Params.Previewimage -}}
-    <meta name="image" property="og:image" content="{{ .Params.Previewimage }}">
-    {{ else -}}
-    <meta name="image" property="og:image" content="{{ .Site.Params.AuthorImgPath }}">
+    {{- if not .IsHome -}}
+    <meta property="og:title" content="{{ .Title }}">
+    {{ end -}}
+
+    {{- if .Site.Social.twitteruser -}}
+    <meta name="twitter:creator" content="{{ .Site.Social.twitteruser }}">
     {{ end }}
 
     {{ "<!-- Any custom header goes here-->" | safeHTML }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,7 +32,7 @@
     <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="/atom.xml" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {{ hugo.Generator }}"
+    {{ hugo.Generator }}
 
     {{- if .Params.tags }}
     <meta name=" keywords" content="{{ delimit .Params.tags "," }}">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -35,7 +35,7 @@
     {{ hugo.Generator }}
 
     {{- if .Params.tags }}
-    <meta name=" keywords" content="{{ delimit .Params.tags "," }}">
+    <meta name="keywords" content="{{ delimit .Params.tags "," }}">
     {{- end }}
 
     {{ $descText := "" -}}


### PR DESCRIPTION
This change adds the following OpenGraph and Twitter specific meta tags to the head so that link previews look better (description, image, etc)

* og:type
* og:image
* og:description
* og:title
* twitter:card
* twitter:creator

Also, fixed the `generator` meta tag since it was wrong as well
